### PR TITLE
Update pyproject.toml to relax pybind version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11~=2.6.1"
+    "pybind11>=2.6.1"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hi, we use this package and would like to upgrade to Python 3.11.

Pybind 11 supports 3.11 since [v2.10.1](https://github.com/pybind/pybind11/releases/tag/v2.10.1)